### PR TITLE
Removed unused 'prod' function parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function handleGetSpace(){
   app.context.getSpace().then((s) => log('getSpace()', s));
 }
 
-function handleSetShare(prod) {
+function handleSetShare() {
   var url = document.getElementById("shareUrl").value
   app.setShareUrl(url, url, 'Embedded App Kitchen Sink');
   log('setShareUrl()', {message:'shared url to participants panel',url:url})


### PR DESCRIPTION
I missed this in a previous PR when I removed the `prod` parameter from the `handleSetShare()` function call but not the function definition.