### PR TITLE
Updates promise handling for context.get*() and setShareURL() methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,22 +12,37 @@ app.onReady().then(() => {
     })
 });
 
-function handleGetUser() {
-    app.context.getUser().then((u) => log('getUser()', u));
+function handleGetUser(){
+    app.context.getUser().then((u) => {
+        log('getUser()', u);
+    }).catch((error) => {
+        log('getUser() promise failed with error', Webex.Application.ErrorCodes[error]);
+    })
 }
 
 function handleGetMeeting() {
-    app.context.getMeeting().then((m) => log('getMeeting()', m));
+    app.context.getMeeting().then((m) => {
+        log('getMeeting()', m);
+    }).catch((error) => {
+        log('getMeeting() promise failed with error', Webex.Application.ErrorCodes[error]);
+    });
 }
 
 function handleGetSpace() {
-    app.context.getSpace().then((s) => log('getSpace()', s));
+    app.context.getSpace().then((s) => {
+        log('getSpace()', s);
+    }).catch((error) => {
+        log('getSpace() promise failed with error', Webex.Application.ErrorCodes[error]);
+    });
 }
 
 function handleSetShare() {
     var url = document.getElementById("shareUrl").value
-    app.setShareUrl(url, url, 'Embedded App Kitchen Sink');
-    log('setShareUrl()', { message: 'shared url to participants panel', url: url })
+    app.setShareUrl(url, url, 'Embedded App Kitchen Sink').then(() => {
+        log('setShareUrl()', { message: 'shared url to participants panel', url: url })
+    }).catch((error) => {
+        log('setShareUrl() failed with error', Webex.Application.ErrorCodes[error]);
+    });
 }
 
 function handleClearShare() {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ app.onReady().then(() => {
     })
 });
 
-function handleGetUser(){
+function handleGetUser() {
     app.context.getUser().then((u) => {
         log('getUser()', u);
     }).catch((error) => {

--- a/participant.js
+++ b/participant.js
@@ -13,15 +13,27 @@ app.onReady().then(() => {
 });
 
 function handleGetUser() {
-  app.context.getUser().then((u) => log('getUser()', u));
+  app.context.getUser().then((u) => {
+    log('getUser()', u);
+  }).catch((error) => {
+    log('getUser() promise failed with error', Webex.Application.ErrorCodes[error]);
+  })
 }
 
 function handleGetMeeting() {
-  app.context.getMeeting().then((m) => log('getMeeting()', m));
+  app.context.getMeeting().then((m) => {
+    log('getMeeting()', m);
+  }).catch((error) => {
+    log('getMeeting() promise failed with error', Webex.Application.ErrorCodes[error]);
+  });
 }
 
 function handleGetSpace() {
-  app.context.getSpace().then((s) => log('getSpace()', s));
+  app.context.getSpace().then((s) => {
+    log('getSpace()', s);
+  }).catch((error) => {
+    log('getSpace() promise failed with error', Webex.Application.ErrorCodes[error]);
+  });
 }
 
 function handleDisplayAppInfo() {


### PR DESCRIPTION
This PR adds `catch()` handling to the `context.get*()` methods. Developers can use this to catch `NOT_SUPPORTED` errors when running the command out of context (i.e. calling `getMeeting()` in a Space).

It also adds Promise handling to the `setShareUrl()` method call.  This will catch `INVALID_ARGUMENT` errors related to passing an invalid domain as the first parameter.

![image](https://user-images.githubusercontent.com/408952/137790867-bff11ff9-d5d7-4f7c-832f-b9b69b3ab229.png)
