### PR TITLE
Added error handling to clearShareURL()

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,11 @@ function handleSetShare() {
 }
 
 function handleClearShare() {
-    app.clearShareUrl();
-    log('clearShareUrl()', { message: 'share url has been cleared' })
+    app.clearShareUrl().then(() => {
+        log('clearShareUrl()', { message: 'share url has been cleared' })
+    }).catch((error) => {
+        log('clearShareUrl() failed with error', Webex.Application.ErrorCodes[error]);
+    });
 }
 
 function handleDisplayAppInfo() {


### PR DESCRIPTION
This PR adds promise error handling to clearShareURL(), which fails with`GENERIC_ERROR` if a sharing session is in progress.

![image](https://user-images.githubusercontent.com/408952/142516200-f795573e-a223-40f0-be64-fcb08530ce27.png)
