### PR TITLE
fix: participant URL to match new repo URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
           id="shareUrl"
           placeholder="URL to open on participant"
           size="45"
-          value="https://webexsamples.github.io/EmbeddedAppSample/participant.html"
+          value="https://webex.github.io/EmbeddedAppKitchenSink/participant.html"
         />
       </div>
       <div>


### PR DESCRIPTION
The old URL was producing a 404 error. 